### PR TITLE
add tea usage guide

### DIFF
--- a/doc/content/getting-started.md
+++ b/doc/content/getting-started.md
@@ -22,6 +22,12 @@ brew tap joerdav/xc
 brew install xc
 ```
 {{% /details %}}
+{{% details "tea" %}}
+With `tea` just use `tea +xc` in place of `xc`.
+```sh
+tea +xc --version
+```
+{{% /details %}}
 {{% details "Snap" %}}
 ```sh
 TODO


### PR DESCRIPTION
`xc` is now installable via `tea` 

https://github.com/teaxyz/pantry.extra/pull/116/files