### PR TITLE
docs: add MacPorts install instructions

### DIFF
--- a/doc/content/getting-started.md
+++ b/doc/content/getting-started.md
@@ -22,6 +22,11 @@ brew tap joerdav/xc
 brew install xc
 ```
 {{% /details %}}
+{{% details "MacPorts" %}}
+```sh
+sudo port install xc
+```
+{{% /details %}}
 {{% details "tea" %}}
 With `tea` just type `xc`.
 ```sh


### PR DESCRIPTION
`xc` is now available in MacPorts: https://ports.macports.org/port/xc/