### PR TITLE
feat: allow escape to quit interactive mode

### DIFF
--- a/cmd/xc/interactive.go
+++ b/cmd/xc/interactive.go
@@ -80,7 +80,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
-		case "ctrl+c", "q":
+		case "ctrl+c", "q", "esc":
 			m.quitting = true
 			return m, tea.Quit
 


### PR DESCRIPTION
Loving the new interactive mode, and noticed that escape didn't quit.

Not sure if there's a reason I don't know about, but it's a minor change, hence this PR.
