### PR TITLE
chore: update nix flake to remove deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
+coverage.out
 dist/
 doc/public/
-
-coverage.out
+result

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668086072,
-        "narHash": "sha256-msFoXI5ThCmhTTqgl27hpCXWhaeqxphBaleJAgD8JYM=",
+        "lastModified": 1701282334,
+        "narHash": "sha256-MxCVrXY6v4QmfTwIysjjaX0XUhqBbxTWWB4HXtDYsdk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72d8853228c9758820c39b8659415b6d89279493",
+        "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "23.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,20 +1,20 @@
 {
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/23.11";
     flake-utils.url = "github:numtide/flake-utils";
-    flake-utils.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
-      let 
+      let
         pkgs = import nixpkgs {
           system = system;
         };
-        xc = pkgs.callPackage ./xc.nix {};
+        xc = pkgs.callPackage ./xc.nix { };
       in
       {
         defaultPackage = xc;
-        packages = { 
+        packages = {
           xc = xc;
         };
         devShells = {

--- a/update-nix.sh
+++ b/update-nix.sh
@@ -5,9 +5,9 @@ sed -e "s/__VERSION__/$(git describe --tags --abbrev=0)/g" xc.nix.tmpl > xc.nix
 # We first try to build and it fails with hash mismatch, and we use it to populate sha256.
 nix-build -E 'with import <nixpkgs> { }; callPackage ./xc.nix { }'
 SRC_SHA256="$(nix-build -E 'with import <nixpkgs> { }; callPackage ./xc.nix { }' 2>&1 | grep -oE 'got:\s+sha256-\S+' | cut -d "-" -f 2)"
-sed -i -e "s|sha256 = lib.fakeSha256;|sha256 = \"$SRC_SHA256\";|g" xc.nix
+sed -i -e "s|sha256 = \"\";|sha256 = \"$SRC_SHA256\";|g" xc.nix
 
 # We try again to build and it fails with hash mismatch, and we use it to populate vendorSha256.
 VENDOR_SHA256="$(nix-build -E 'with import <nixpkgs> { }; callPackage ./xc.nix { }' 2>&1 | grep -oE 'got:\s+sha256-\S+' | cut -d "-" -f 2)"
-sed -i -e "s|vendorSha256 = lib.fakeSha256;|vendorSha256 = \"$VENDOR_SHA256\";|g" xc.nix
+sed -i -e "s|vendorHash = \"\";|vendorHash = \"sha256-$VENDOR_SHA256\";|g" xc.nix
 

--- a/xc.nix
+++ b/xc.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, fetchFromGitHub, ... }:
+{ config, pkgs, fetchFromGitHub, ... }:
 
 pkgs.buildGoModule rec {
   pname = "xc";

--- a/xc.nix
+++ b/xc.nix
@@ -3,12 +3,12 @@
 pkgs.buildGoModule rec {
   pname = "xc";
   version = "v0.8.0";
-  subPackages = ["cmd/xc"];
+  subPackages = [ "cmd/xc" ];
   src = pkgs.fetchFromGitHub {
     owner = "joerdav";
     repo = "xc";
     rev = version;
     sha256 = "vTyCS85xbJnAgbasWD6LFxij9EezzlJ1pyvCJptqmOU=";
   };
-  vendorSha256 = "EbIuktQ2rExa2DawyCamTrKRC1yXXMleRB8/pcKFY5c=";
+  vendorHash = "sha256-EbIuktQ2rExa2DawyCamTrKRC1yXXMleRB8/pcKFY5c=";
 }

--- a/xc.nix.tmpl
+++ b/xc.nix.tmpl
@@ -1,14 +1,14 @@
-{ config, lib, pkgs, fetchFromGitHub, ... }:
+{ config, pkgs, fetchFromGitHub, ... }:
 
 pkgs.buildGoModule rec {
   pname = "xc";
   version = "__VERSION__";
-  subPackages = ["cmd/xc"];
+  subPackages = [ "cmd/xc" ];
   src = pkgs.fetchFromGitHub {
     owner = "joerdav";
     repo = "xc";
     rev = version;
-    sha256 = lib.fakeSha256;
+    sha256 = "";
   };
-  vendorHash = lib.fakeSha256;
+  vendorHash = "";
 }

--- a/xc.nix.tmpl
+++ b/xc.nix.tmpl
@@ -10,5 +10,5 @@ pkgs.buildGoModule rec {
     rev = version;
     sha256 = lib.fakeSha256;
   };
-  vendorSha256 = lib.fakeSha256;
+  vendorHash = lib.fakeSha256;
 }


### PR DESCRIPTION
I always get this warning from running `nix shell github:joerdav/xc`:

```
trace: warning: `vendorSha256` is deprecated. Use `vendorHash` instead
```
