### PR TITLE
chore: simplify test with t.Setenv

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,6 +25,7 @@ linters:
     - nolintlint
     - staticcheck
     - stylecheck
+    - tenv
     - typecheck
     - unconvert
     - unparam

--- a/run/run_test.go
+++ b/run/run_test.go
@@ -3,7 +3,6 @@ package run
 import (
 	"context"
 	"errors"
-	"os"
 	"sync"
 	"testing"
 
@@ -272,8 +271,7 @@ func TestRunWithInputs(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		os.Setenv("FOO", "BAR")
-		defer os.Unsetenv("FOO")
+		t.Setenv("FOO", "BAR")
 		scriptRunner := &mockScriptRunner{}
 		runner.scriptRunner = scriptRunner
 		err = runner.Run(context.Background(), "task", nil)


### PR DESCRIPTION
The PR refactors `TestRunWithInputs` by changing to use https://pkg.go.dev/testing#T.Setenv instead of `os.Setenv`:

> Setenv calls os.Setenv(key, value) and uses Cleanup to restore the environment variable to its original value after the test.

This is detected with `tenv` linter.

