### PR TITLE
fix: add missing file closing

### DIFF
--- a/run/interpreter.go
+++ b/run/interpreter.go
@@ -66,11 +66,14 @@ func (i interpreter) executeShebang(
 ) error {
 	f, err := os.CreateTemp("", i.tempFilePrefix)
 	if err != nil {
-		return fmt.Errorf("failed to create execution file")
+		return fmt.Errorf("failed to create execution file: %w", err)
 	}
 	defer os.Remove(f.Name())
 	if _, err = f.WriteString(text); err != nil {
-		return fmt.Errorf("failed to write execution file")
+		return fmt.Errorf("failed to write execution file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close execution file: %w", err)
 	}
 	interpreterArgs = append(interpreterArgs, f.Name())
 	cmd := exec.CommandContext(ctx, interpreterCmd, append(interpreterArgs, args...)...)


### PR DESCRIPTION
[CreateTemp](https://pkg.go.dev/os#CreateTemp) creates a new temporary file in the directory dir, opens the file for reading and writing, and returns the resulting file. So, it's the caller's responsibility to close the file, which is done in this PR.

Additionally, the PR changes error messages to return the original error.