### PR TITLE
chore: fix typo in "GitHub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
 
 ![xc](https://user-images.githubusercontent.com/19927761/156772881-10065864-ff4d-4225-ab2b-5adbbe628845.png)
-[Docs](https://xcfile.dev/) | [Getting Started](https://xcfile.dev/getting-started/) | [Github](https://github.com/joerdav/xc)
+[Docs](https://xcfile.dev/) | [Getting Started](https://xcfile.dev/getting-started/) | [GitHub](https://github.com/joerdav/xc)
 
 [![xc compatible](https://xcfile.dev/badge.svg)](https://xcfile.dev)
 [![test](https://github.com/joerdav/xc/actions/workflows/test.yaml/badge.svg)](https://github.com/joerdav/xc/actions/workflows/test.yaml) 


### PR DESCRIPTION
The PR corrects a typo in the "GitHub" company name. See https://en.wikipedia.org/wiki/GitHub