### PR TITLE
chore: fix 404 page

### DIFF
--- a/doc/app.yaml
+++ b/doc/app.yaml
@@ -10,4 +10,7 @@ handlers:
   upload: public/(.*)
 - url: /
   static_dir: public/
-
+- url: /.*
+  static_files: public/404.html
+  upload: public/404.html
+  error_code: 404

--- a/doc/layouts/404.html
+++ b/doc/layouts/404.html
@@ -1,5 +1,13 @@
 {{ define "main" }}
-	<h1>Page not found</h1>
+<header>
+	<span class="content">
+		<h1>Page not found</h1>
+	</span>
+</header>
+<main>
 
-	I'm sorry, but the requested page wasn’t found on the server.
+<div class="content">
+	<p>I'm sorry, but the requested page wasn’t found on the server. Try going back to the <a href="{{ "" | relURL }}">home page</a>.</p>
+</div>
+</main>
 {{ end }}


### PR DESCRIPTION
The PR fixes the display of the 404 page on GCP App Engine by modifying `doc/app.yaml` (I'm not 100% sure if this helps because I can't deploy it without GCP permissions). It also slightly modifies the style of the error page.

Before:

<img width="833" alt="image" src="https://github.com/user-attachments/assets/920ab80d-aa51-4e10-aa54-29e3bcbbf666" />


After:

<img width="935" alt="image" src="https://github.com/user-attachments/assets/6d44790f-8f07-4ec8-95f6-08e78c98a61e" />



Fixes #80 