### PR TITLE
docs: update AUR installation instructions for xc

### DIFF
--- a/doc/content/getting-started.md
+++ b/doc/content/getting-started.md
@@ -73,8 +73,12 @@ scoop install xc
 ```
 {{% /details %}}
 {{% details "AUR" %}}
+
+Use `yay` or any AUR helper that you like to install the `xc` package.
+You can also install the pre-compiled package named `xc-bin` or the `xc-git` that follows the latest commit.
+
 ```sh
-TODO
+yay -S xc
 ```
 {{% /details %}}
 


### PR DESCRIPTION
Add instructions for installing xc via AUR helpers.

Users can install `xc` via these packages [xc](https://aur.archlinux.org/packages/xc) [xc-bin](https://aur.archlinux.org/packages/xc-bin) [xc-git](https://aur.archlinux.org/packages/xc-git) that are currently maintained by me. :)