### PR TITLE
Add Emacs integration links to README & ide-support.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Installation instructions are described at <https://xcfile.dev/getting-started/#
 	- [VSCode](https://marketplace.visualstudio.com/items?itemName=xc-vscode.xc-vscode) (list and run `xc` tasks)
 	  ![vscode demo](https://user-images.githubusercontent.com/19927761/214538057-963f9a47-ff95-486c-8856-b90bd358be3f.png)
 	- [Vim](https://xcfile.dev/ide-support/#vim) (recommended config for listing and running `xc` tasks)
+    - [Emacs](https://codeberg.org/ryanprior/xc.el)
+      ![emacs demo](https://codeberg.org/ryanprior/xc.el/media/branch/main/screenshot-v1.png)
 - See also: [`org-mode` specific features](https://xcfile.dev/org-mode-features).
 
 # Example

--- a/doc/content/ide-support.md
+++ b/doc/content/ide-support.md
@@ -19,4 +19,8 @@ Just use the following config:
 
 ```
 :map <leader>xc :call fzf#run({'source':'xc -short', 'options': '--prompt "xc> " --preview "xc -md {}"', 'sink': 'RunInInteractiveShell xc', 'window': {'width': 0.9, 'height': 0.6}})
-```
+``**
+
+## Emacs
+
+Extension: <https://codeberg.org/ryanprior/xc.el>


### PR DESCRIPTION
## Why?

I put together an [Emacs integration](https://codeberg.org/ryanprior/xc.el) for xc. It provides an interactive command runner & integrates xc tasks into the Treemacs side-bar. I hope users of Emacs & xc will give it a try.

## What does this PR do?

- Updates README with link to the Emacs integration & includes a demo screenshot (is this too many demo screenshots when it's two of them?)
- Updates the "IDE support" page in the docs with a link to the Emacs extension.

## What's next?

This works as-is for my common use cases. I've got various ideas for extending it, like a "rerun last xc task" function, or adding support for tasks with inputs. It would also be nice to get this into GNU Elpa for easy installation.