### PR TITLE
Add community link to my blog post

### DIFF
--- a/doc/content/community.md
+++ b/doc/content/community.md
@@ -10,3 +10,4 @@ menu: { main: {  weight: 11 } }
 - [Introducing the XC README task runner](https://blog.joe-davidson.co.uk/posts/introducing-the-xc-readme-task-runner/)
 - [Runnable READMEs w/ xc](https://dev.to/adriens/runnable-readmes-w-xc-1c6d) (FR)
 - [MarkdownベースのGo製タスクランナー「xc」のススメ (Recommendation of "xc", a Markdown-based Task Runner Written in Go)](https://zenn.dev/trap/articles/af32614c07214d) (Japanese)
+- [Put Your Runbook in Your README](https://www.ryanprior.com/posts/put-your-runbook-in-your-readme/) (EN)


### PR DESCRIPTION
I just published [a blog post about xc](https://www.ryanprior.com/posts/put-your-runbook-in-your-readme/) and about runbooks more broadly, so that I have an easy reference to share why I'm using xc & contributing to it. This PR adds a link to the "community" page.

Thank you for designing & maintaining a nice piece of software!