### PR TITLE
Clean up deprecation message for multiple interactive tasks

### DIFF
--- a/cmd/xc/deprecation.go
+++ b/cmd/xc/deprecation.go
@@ -8,13 +8,24 @@ import (
 )
 
 func warnInteractive(tasks models.Tasks) {
-	var logger = log.New(os.Stderr, "warning: xc: ", 0)
+	var interactiveTasks []string
 	for _, task := range tasks {
 		if task.Interactive {
+			interactiveTasks = append(interactiveTasks, task.Name)
+		}
+	}
+	if len(interactiveTasks) > 0 {
+		logger := log.New(os.Stderr, "warning: xc: ", 0)
+		if len(interactiveTasks) == 1 {
 			logger.Printf(`Task "%s" is set to Interactive,
              which is a deprecated attribute that has no effect.
              You can safely remove the attribute.
-             (see https://github.com/joerdav/xc/issues/127)`, task.Name)
+             (see https://github.com/joerdav/xc/issues/127)`, interactiveTasks[0])
+		} else {
+			logger.Printf(`Tasks %v are set to Interactive,
+             which is a deprecated attribute that has no effect.
+             You can safely remove the attribute.
+             (see https://github.com/joerdav/xc/issues/127)`, interactiveTasks)
 		}
 	}
 }

--- a/cmd/xc/deprecation_test.go
+++ b/cmd/xc/deprecation_test.go
@@ -51,3 +51,52 @@ func TestInteractiveWarning(t *testing.T) {
 		t.Fatal("warning explanation does not contain repo link")
 	}
 }
+
+func TestInteractiveWarningMultiple(t *testing.T) {
+	tasks := models.Tasks{
+		{
+			Name:        "task1",
+			Script:      "echo task1",
+			Interactive: true,
+		},
+		{
+			Name:   "task2",
+			Script: "echo task2",
+		},
+		{
+			Name:        "task3",
+			Script:      "echo task3",
+			Interactive: true,
+		},
+	}
+	orig := os.Stderr
+	r, w, _ := os.Pipe()
+	defer w.Close()
+	defer r.Close()
+	os.Stderr = w
+	defer func() {
+		os.Stderr = orig
+	}()
+	warnInteractive(tasks)
+	w.Close()
+	os.Stderr = orig
+	res, _ := io.ReadAll(r)
+	result := string(res)
+
+	// Should contain both task names in a single warning
+	if !strings.Contains(result, "task1") {
+		t.Fatal("warning does not contain task1")
+	}
+	if !strings.Contains(result, "task3") {
+		t.Fatal("warning does not contain task3")
+	}
+	if !strings.Contains(result, "Interactive") {
+		t.Fatal("warning does not contain 'Interactive'")
+	}
+
+	// Should only have one warning message (count occurrences of "warning:")
+	warningCount := strings.Count(result, "warning: xc:")
+	if warningCount != 1 {
+		t.Fatalf("expected 1 warning message, got %d", warningCount)
+	}
+}


### PR DESCRIPTION
@ryanprior a bit of use across repos with that flag set, the log message became a bit noisy. So updating before I cut a release!