### PR TITLE
Add --list alias for listing tasks

### DIFF
--- a/cmd/xc/main.go
+++ b/cmd/xc/main.go
@@ -67,6 +67,7 @@ func flags() config {
 
 	flag.BoolVar(&cfg.short, "short", false, "list task names in a short format")
 	flag.BoolVar(&cfg.short, "s", false, "list task names in a short format")
+	flag.BoolVar(&cfg.short, "list", false, "list task names in a short format")
 
 	flag.BoolVar(&cfg.display, "d", false, "print the plain text code of a task rather than running it")
 	flag.BoolVar(&cfg.display, "display", false, "print the plain text code of a task rather than running it")
@@ -294,6 +295,7 @@ func completion(tasks models.Tasks) *complete.Command {
 			"file":    predict.Files("*.md"),
 			"s":       predict.Nothing,
 			"short":   predict.Nothing,
+			"list":    predict.Nothing,
 			"d":       predict.Nothing,
 			"display": predict.Nothing,
 			"H":       predict.Nothing,

--- a/cmd/xc/usage.txt
+++ b/cmd/xc/usage.txt
@@ -13,7 +13,7 @@ xc
   Interactive picker for xc tasks.
   If -file is not specified and no README.md is found in the current directory,
     xc will search in parent directories for convenience.
-  -s -short
+  -s -short -list
         List task names in a short format.
   -no-tty
 	Disable interactive mode.


### PR DESCRIPTION
Closes https://github.com/joerdav/xc/issues/145

 This PR adds `--list` as an alias for `-s/--short` to make listing tasks more intuitive and discoverable.                                                                     