### PR TITLE
Add Guix manifest

### DIFF
--- a/guix.scm
+++ b/guix.scm
@@ -1,0 +1,20 @@
+(define-module (guix)
+  #:use-module (guix packages)
+  #:use-module (guix gexp)
+  #:use-module (guix git-download)
+  #:use-module (gnu packages task-runners)
+  #:use-module (guix utils))
+
+(define-public xc-dev
+  (package
+   (inherit xc)
+   (version "0.dev")
+   (source
+    (local-file
+     "." "xc-checkout"
+     #:recursive? #t
+     #:select? (lambda* (#:rest _)
+                 (or (git-predicate (current-source-directory))
+                     (const #t)))))))
+
+xc-dev


### PR DESCRIPTION
This PR adds `guix.scm`, providing a package for `xc` which uses the local source files in the git working tree instead of building from the last tagged release.

## Outcomes for Guix users
Guix users working on xc will benefit in a variety of cases:
|use case|example|
|-|-|
|provision a dev environment with all dependencies | `guix shell --development` |
|test whether the current git tree will build in Guix | `guix build --file=guix.scm` |
|check for undeclared runtime dependencies | `guix shell --container --file=guix.scm -- xc` |

## No documentation changes
This shouldn't have any impact on non-Guix users, and there's no documentation for Nix users presently, so I decided not to add any for this. If you would welcome it, I can write a paragraph in the README about using Guix for development.

## Guix upstream
Upstream Guix accepted my patch to include the package for xc and its dependencies, which means we can ship a lean `guix.scm`.