### PR TITLE
Removes "Go Report Card" badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![docs](https://github.com/joerdav/xc/actions/workflows/docs.yml/badge.svg)](https://github.com/joerdav/xc/actions/workflows/docs.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/joerdav/xc.svg)](https://pkg.go.dev/github.com/joerdav/xc)
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
-[![Go Report Card](https://goreportcard.com/badge/github.com/joerdav/xc)](https://goreportcard.com/report/github.com/joerdav/xc)
 [![Coverage Status](https://coveralls.io/repos/github/joerdav/xc/badge.svg?branch=main)](https://coveralls.io/github/joerdav/xc?branch=main)
 
 </div>


### PR DESCRIPTION
The report card service [is sunset](https://goreportcard.com/report/github.com/joerdav/xc). Their recommendation is to instead use golangci-lint, which we already use.